### PR TITLE
Add traverse option for deeply nested mbean values

### DIFF
--- a/examples/riemann.config
+++ b/examples/riemann.config
@@ -10,8 +10,14 @@
   (ws-server {:host host :port 8087})
 )
 
-(mbeans/instrumentation {:interval 10 :mbeans [{:mbean "java.lang:type=Memory" :property :HeapMemoryUsage :attribute :used}
-                                               {:mbean "java.lang:type=Runtime" :property :Uptime}]})
+(mbeans/instrumentation
+  {:interval 10
+   :mbeans [{:mbean "java.lang:type=Memory" :property :HeapMemoryUsage :attribute :used}
+            {:mbean "java.lang:type=Runtime" :property :Uptime}
+            {:mbean "java.lang:type=GarbageCollector,name=ParNew"
+             :traverse (list :LastGcInfo :memoryUsageAfterGc (keyword "Code Cache") :value :used)}
+            {:mbean "java.lang:type=GarbageCollector,name=ParNew"
+             :traverse (list :LastGcInfo :memoryUsageAfterGc (keyword "Par Eden Space") :value :used)}]})
 
 (let [index (index)]
   (streams index))

--- a/src/riemann/plugin/mbeans.clj
+++ b/src/riemann/plugin/mbeans.clj
@@ -9,11 +9,15 @@
 
 (defn eat-bean
   "takes a map describing mbean. returns a map containing the corresponding metric in the :metric value and the name in the :service value"
-  [{:keys [mbean property attribute service]}]
-  (let [service (or service (str mbean property attribute))]
-    (if attribute
-      {:service service :metric (attribute (jmx/read mbean property))}
-      {:service service :metric (jmx/read mbean property)})))
+  [{:keys [mbean property attribute traverse service]}]
+  (if traverse
+    (let [service (or service (apply str (cons mbean traverse)))
+          metric (get-in (jmx/read mbean (first traverse)) (rest traverse))]
+      {:service service :metric metric})
+    (let [service (or service (str mbean property attribute))]
+      (if attribute
+        {:service service :metric (attribute (jmx/read mbean property))}
+        {:service service :metric (jmx/read mbean property)}))))
 
 (defn eat-beans
   "takes a sequence of maps describing mbeans. returns a sequence of maps containing the corresponding metrics in the :metric value"


### PR DESCRIPTION
I decided to make this easier for the user who can just give a list of keys instead of having to write a function to apply.
